### PR TITLE
Fix the issue when attempting to run docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,5 @@ RUN dotnet publish "DotNetMetadataMcpServer.csproj" -c Release -o /app/publish
 FROM base AS final
 WORKDIR /app
 COPY --from=publish /app/publish .
+ENV HOME /app
 ENTRYPOINT ["dotnet", "DotNetMetadataMcpServer.dll"]

--- a/DotNetMetadataMcpServer/Program.cs
+++ b/DotNetMetadataMcpServer/Program.cs
@@ -18,18 +18,27 @@ public class Program
     /// <returns></returns>*/
     public static async Task<int> Main(string[] args)
     {
+        string homeEnvVariable = string.Empty;
+
         if (args.Length < 2 || string.IsNullOrWhiteSpace(args[0]) || args[0] != "--homeEnvVariable" || string.IsNullOrWhiteSpace(args[1]))
         {
-            Console.WriteLine("The --homeEnvVariable argument with a value is required");
-            return 1;
-        } 
-        
+            homeEnvVariable = Environment.GetEnvironmentVariable("HOME");
+            if (string.IsNullOrWhiteSpace(homeEnvVariable))
+            {
+                Console.WriteLine("The --homeEnvVariable argument with a value is required");
+                return 1;
+            }
+        }
+        else
+        {
+            homeEnvVariable = args[1];
+        }
+
         var configuration = new ConfigurationBuilder()
             .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
             .AddEnvironmentVariables()
             .Build();
         
-        var homeEnvVariable = args[1];
         Environment.SetEnvironmentVariable("HOME", homeEnvVariable);
         
         var logger = new LoggerConfiguration()


### PR DESCRIPTION
Fix the issue with the `--homeEnvVariable` argument when running docker.

* Modify `DotNetMetadataMcpServer/Program.cs` to check for the `HOME` environment variable if the `--homeEnvVariable` argument is not provided.
* Use the `HOME` environment variable if the `--homeEnvVariable` argument is missing or its value is empty.
* Set a default value for the `HOME` environment variable in the `Dockerfile`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/cege7480/DotNetMetadataMcpServer/pull/2?shareId=2c9a502f-8015-496c-b93e-9e52d64289c1).